### PR TITLE
Bring Nibs into the 2018s... update all package dependencies and fix …

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,23 +18,26 @@
   },
   "homepage": "https://github.com/ccoenraets/loyalty",
   "engines": {
-    "node": "0.10.35"
+    "node": "10.7.0"
   },
   "dependencies": {
-    "logfmt": "~0.21.0",
-    "bcrypt": "~0.7.7",
-    "pg": "~2.11.1",
-    "node-uuid": "~1.4.1",
-    "validator": "~3.5.0",
-    "winston": "~0.7.3",
+    "bcrypt": "3.0.1",
+    "body-parser": "1.18.3",
+    "compression": "1.7.3",
+    "cookie-session": "1.3.2",
+    "ejs": "2.6.1",
+    "express": "4.16.3",
+    "hoek": "^5.0.4",
+    "libpq": "^1.8.8",
+    "logfmt": "1.2.1",
+    "method-override": "3.0.0",
+    "nforce": "1.10.0",
+    "pg": "7.4.3",
+    "pg-native": "^3.0.0",
     "q": "~1.0.1",
-    "nforce": "~0.8.0-beta.1",
-    "express": "~4.4.1",
-    "body-parser": "~1.3.0",
-    "method-override": "~2.0.1",
-    "compression": "~1.0.11",
-    "request": "~2.40.0",
-    "ejs": "~1.0.0",
-    "cookie-session": "~1.0.2"
+    "request": "2.88.0",
+    "uuid": "3.3.2",
+    "validator": "10.7.1",
+    "winston": "3.1.0"
   }
 }

--- a/server.js
+++ b/server.js
@@ -23,9 +23,10 @@ var express = require('express'),
     app = express();
 
 app.set('port', process.env.PORT || 5000);
-
 app.use(compression());
-app.use(bodyParser({
+
+//  body-parser deprecated bodyParser() constructor: use individual json/urlencoded middleware
+app.use(bodyParser.json({
     uploadDir: __dirname + '/uploads',
     keepExtensions: true
 }));

--- a/server/auth.js
+++ b/server/auth.js
@@ -1,7 +1,7 @@
 var bcrypt = require('bcrypt'),
     db = require('./pghelper'),
     config = require('./config'),
-    uuid = require('node-uuid'),
+    uuidv4 = require('uuid/v4'),
     Q = require('q'),
     validator = require('validator'),
     winston = require('winston'),
@@ -48,7 +48,7 @@ function comparePassword(password, hash, callback) {
  */
 function createAccessToken(user) {
     winston.info('createAccessToken');
-    var token = uuid.v4(),
+    var token = uuidv4(),
         deferred = Q.defer();
     
     db.query('INSERT INTO tokens (userId, externalUserId, token) VALUES ($1, $2, $3)', [user.id, user.externaluserid, token])

--- a/server/pghelper.js
+++ b/server/pghelper.js
@@ -1,8 +1,12 @@
-var pg = require('pg').native,
-    config = require('./config'),
+var config = require('./config'),
     Q = require('q'),
     winston = require('winston'),
     databaseURL = config.databaseURL;
+
+const { Client, Pool } = require('pg').native
+const pg = new Pool({
+    connectionString: databaseURL,
+  })
 
 /**
  * Utility function to execute a SQL query against a Postgres database
@@ -19,7 +23,8 @@ exports.query = function (sql, values, singleItem, dontLog) {
 
     var deferred = Q.defer();
 
-    pg.connect(databaseURL, function (err, conn, done) {
+//    pg.connect(databaseURL, function (err, conn, done) {
+    pg.connect(function (err, conn, done) {
         if (err) return deferred.reject(err);
         try {
             conn.query(sql, values, function (err, result) {


### PR DESCRIPTION
…on version updates

- package.json had ancient deps - updated to the latest
- server.js just needed a slight nudge with a deprecated body-parser ctor
- server/auth.js neened to swap out the node-uuid for the uuid module
- server/pghelper.js need some help with the latest node-postgres module

All needed to be done in order to upgrade to the latest Heroku Stack - Heroku-18.

Not hugely tested, but works without a database, and with a database, and with Heroku Connect.

Looks ok to me :)